### PR TITLE
Expanded metadata types and set default analysis provider

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,6 +1,6 @@
 {
   "access_right": "open",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "creators": [
     {
       "orcid": "0000-0003-0665-098X",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,6 +5,6 @@ authors:
     given-names: Eidan J.
     orcid: https://orcid.org/0000-0003-0665-098X
 title: "pii-codex: a Python library for PII detection, categorization, and severity assessment"
-version: 0.2.2
+version: 0.2.3
 doi: 10.5281/zenodo.7212576
-date-released: 2022-10-22
+date-released: 2022-10-23

--- a/pii_codex/models/common.py
+++ b/pii_codex/models/common.py
@@ -26,8 +26,10 @@ class RiskLevelDefinition(Enum):
 
 class MetadataType(Enum):
     SCREEN_NAME: str = "screen_name"
+    NAME: str = "name"
     LOCATION: str = "location"
     URL: str = "url"
+    USER_ID: str = "user_id"
 
 
 class PIIType(Enum):

--- a/pii_codex/services/analysis_service.py
+++ b/pii_codex/services/analysis_service.py
@@ -42,9 +42,9 @@ class PIIAnalysisService:
     @timed_operation
     def analyze_item(
         self,
-        analysis_provider: str,
         text: str,
         metadata: dict = None,
+        analysis_provider: str = AnalysisProviderType.PRESIDIO.name,
         language_code: str = "en",
     ) -> AnalysisResult:
         """
@@ -311,6 +311,25 @@ class PIIAnalysisService:
                     )
 
         return analysis_result_items
+
+    @staticmethod
+    def summarize_analysis_result_items(
+        analyses: List[AnalysisResultItem], index=0
+    ) -> AnalysisResult:
+        """
+        Summarize analysis result items into a singular AnalysisResult object
+
+        @param analyses:
+        @param index:
+        @return:
+        """
+        return AnalysisResult(
+            index=index,
+            analysis=analyses,
+            risk_score_mean=get_mean(
+                [analysis.risk_assessment.risk_level for analysis in analyses]
+            ),
+        )
 
     def _build_analysis_result_set(
         self,

--- a/pii_codex/utils/pii_mapping_util.py
+++ b/pii_codex/utils/pii_mapping_util.py
@@ -177,6 +177,14 @@ class PIIMapper:
         """
 
         try:
+            if metadata_type.lower() == "name":
+                return PIIType.PERSON
+
+            if metadata_type.lower() == "user_id":
+                # If dealing with public data, user_id can be used to pull down
+                # social network profile
+                return PIIType.SOCIAL_NETWORK_PROFILE
+
             return PIIType[MetadataType(metadata_type.lower()).name]
         except Exception as ex:
             raise Exception(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pii-codex"
-version = "0.2.2"
+version = "0.2.3"
 description = ""
 authors = ["Eidan J. Rosado"]
 license = "BSD 3-Clause"

--- a/tests/pii_codex/services/test_analysis_service.py
+++ b/tests/pii_codex/services/test_analysis_service.py
@@ -96,13 +96,55 @@ class TestPIIAnalysisService:
         ]
 
         metadata_to_analyze = [
-            {"location": True, "url": False, "screen_name": True},
-            {"location": False, "url": False, "screen_name": True},
-            {"location": False, "url": False, "screen_name": True},
-            {"location": True, "url": False, "screen_name": True},
-            {"location": True, "url": False, "screen_name": True},
-            {"location": False, "url": False, "screen_name": True},
-            {"location": True, "url": False, "screen_name": True},
+            {
+                "location": True,
+                "url": False,
+                "screen_name": True,
+                "name": True,
+                "user_id": True,
+            },
+            {
+                "location": False,
+                "url": False,
+                "screen_name": True,
+                "name": True,
+                "user_id": True,
+            },
+            {
+                "location": False,
+                "url": False,
+                "screen_name": True,
+                "name": True,
+                "user_id": True,
+            },
+            {
+                "location": True,
+                "url": False,
+                "screen_name": True,
+                "name": True,
+                "user_id": True,
+            },
+            {
+                "location": True,
+                "url": False,
+                "screen_name": True,
+                "name": True,
+                "user_id": True,
+            },
+            {
+                "location": False,
+                "url": False,
+                "screen_name": True,
+                "name": True,
+                "user_id": True,
+            },
+            {
+                "location": True,
+                "url": False,
+                "screen_name": True,
+                "name": True,
+                "user_id": True,
+            },
         ]
 
         test_df = pd.DataFrame.from_dict(
@@ -124,15 +166,15 @@ class TestPIIAnalysisService:
             results.analyses[0].index
         )
         assert_that(results.risk_score_mean).is_greater_than(1)
-        assert_that(results.detection_count).is_equal_to(
-            21
+        assert_that(results.detection_count).is_greater_than(
+            30
         )  # Emails double as domain detections
         assert_that(
             results.detected_pii_type_frequencies.most_common(1)[0][0]
-        ).is_equal_to("SCREEN_NAME")
-        assert_that(results.risk_score_standard_deviation).is_greater_than(0.3)
+        ).is_equal_to("PERSON")
+        assert_that(results.risk_score_standard_deviation).is_greater_than(0.12)
         assert_that(results.detection_count).is_greater_than(10)
-        assert_that(results.risk_score_variance).is_greater_than(0.11)
+        assert_that(results.risk_score_variance).is_greater_than(0.03)
         assert_that(results.to_dict()).is_not_none()
 
     @pytest.mark.parametrize(
@@ -270,3 +312,21 @@ class TestPIIAnalysisService:
                 PIIType,
             )
         ).is_true()
+
+    def test_summarize_analysis_result_items(self):
+
+        result_items = self.pii_analysis_service.analyze_metadata(
+            metadata={
+                "location": True,
+                "url": False,
+                "screen_name": True,
+                "name": True,
+                "user_id": True,
+            }
+        )
+
+        summarized_result = self.pii_analysis_service.summarize_analysis_result_items(
+            analyses=result_items
+        )
+
+        assert_that(isinstance(summarized_result, AnalysisResult)).is_true()


### PR DESCRIPTION
### Overview

PR description. Explain what it's doing and why.

- Expanded metadata types associated with social media
- Updated AnalyzeItem call to have default AnalysisProvider (Presidio)

### Checklist

- [ ] New PII Detection Service Added (Optional)
- [ ] New PII Mappings added (Optional)
- [ ] New citations added (if using other open source or research software) (Optional)
- [ ] New PII types added to new version file under pii_codex/data (and JSON file generated) (Optional)
- [x] Tests added
- [x] CI passed
- [x] Commits Squashed